### PR TITLE
Bugfix/footer and input style

### DIFF
--- a/packages/components/src/components/Footer/index.module.scss
+++ b/packages/components/src/components/Footer/index.module.scss
@@ -42,6 +42,7 @@ $limit: 500;
     justify-self: start;
     justify-content: space-between;
     max-width: 225px;
+    width: 100%;
 
     @include mediaQuery("<=500px") {
       grid-column: 1 / span 2;

--- a/packages/components/src/components/Input/index.module.scss
+++ b/packages/components/src/components/Input/index.module.scss
@@ -69,7 +69,7 @@ $input__padding: 6px 0 7px;
     &:not(.empty) {
       .input__label {
         font-size: 0.85em;
-        height: 1.1884em;
+        height: 1.17647em;
         transform: translate(0px, 0px);
       }
     }

--- a/packages/jobboard/website/src/components/Footer/index.module.scss
+++ b/packages/jobboard/website/src/components/Footer/index.module.scss
@@ -22,5 +22,4 @@
 .image {
   height: auto;
   width: 100%;
-  min-width: 200px;
 }


### PR DESCRIPTION
Logo in footer won't overlap with other elements anymore. 
Label in input component will preserve height of 1em when font shrinks to 0.85em. 