### PR TITLE
add minimal height for description to prevent jumps

### DIFF
--- a/packages/company/website/src/components/OurWorkProcess/index.module.scss
+++ b/packages/company/website/src/components/OurWorkProcess/index.module.scss
@@ -101,6 +101,7 @@
   margin-top: 25px;
   line-height: 1.8;
   animation: enter 1.6s;
+  min-height: 115px;
 }
 
 @keyframes enter {


### PR DESCRIPTION
Out work process section won't jump no more if description content changes in height. 