### PR TITLE
fixed screen height

### DIFF
--- a/packages/jobboard/website/src/components/Newsletter/layout.module.scss
+++ b/packages/jobboard/website/src/components/Newsletter/layout.module.scss
@@ -1,6 +1,6 @@
 @import '@crocoder-dev/components/lib/scss/main.module.scss';
 
-$footer__height--desktop: 150px;
+$footer__height--desktop: 131.25px;
 $navigation__height--desktop: 100px;
 
 .section {

--- a/packages/jobboard/website/src/components/PostAJob/layout.module.scss
+++ b/packages/jobboard/website/src/components/PostAJob/layout.module.scss
@@ -1,13 +1,13 @@
 @import '@crocoder-dev/components/lib/scss/main.module.scss';
 
-$footer__height--desktop: 150px;
+$footer__height--desktop: 131.25px;
 $navigation__height--desktop: 100px;
 
 .section {
   position: relative;
   padding-top: 0 !important; // TODO fix with next component library
-  
 
+  
   @include mediaQuery(">=1000px") {
     min-height: 650px;
     height: calc(100vh - #{$footer__height--desktop} - #{$navigation__height--desktop});


### PR DESCRIPTION
Post a job site and newsletter/subscribe, newsletter/unsubscribe has a small white line as the height of the page is smaller than the screen height. Not anymore! 

Footer height was set to 150px instead of 131.25px.