### PR TITLE
set focused style only when not disabled

### DIFF
--- a/packages/components/src/components/Button/index.module.scss
+++ b/packages/components/src/components/Button/index.module.scss
@@ -39,11 +39,14 @@
     border-color: $lightColor;
   }
 
-  &:focus {
-    outline: none;
-    background-color: $lightColor;
-    border-color: $contrast;
+  &:not(:disabled) {
+    &:focus {
+      outline: none;
+      background-color: $lightColor;
+      border-color: $contrast;
+    }
   }
+
 }
 
 // Primary variant


### PR DESCRIPTION
Fix for: If button is disabled its color should stay gray all the time. However, on Firefox there is a bug when button becomes disabled, it will change color to green when it is not hovered but its still focused. Once button looses focus, it will stay gray until it becomes enabled again.