### PR TITLE
Bugfix/newsletter subscribe not leading anywhere

### DIFF
--- a/packages/jobboard/website/content/newsletter/newsletter.json
+++ b/packages/jobboard/website/content/newsletter/newsletter.json
@@ -7,7 +7,8 @@
       "image": "../images/newsletter-already-confirmed.png",
       "subtitle": "ALREADY CONFIRMED",
       "text": "We’re happy to see you’re excited to use our service, however we must let you know that you already subscribed with this email address and it has been confirmed before. Guess there is nothing more for you to do but to relax and wait for the next job opportunity!",
-      "buttonText": "BROWSE JOBS"
+      "buttonText": "BROWSE JOBS",
+      "buttonLinkTo": "/"
     } ,
     "SUCCESS": {
       "ref": "SUCCESS",
@@ -16,16 +17,18 @@
       "image": "../images/newsletter-subscribe-success.png",
       "subtitle": "successful subscribe",
       "text": "You have successfully confirmed your email and are now subscribed to CroCoder’s newsletter. We’ll keep you posted on all interesting remote roles we find. Stay tuned!",
-      "buttonText": "BROWSE JOBS"
+      "buttonText": "BROWSE JOBS",
+      "buttonLinkTo": "/"
     },
     "DEFAULT": {
       "ref": "ERROR",
-      "title": "We Have Erred",
+      "title": "We Have Error",
       "titleColor": "negative",
       "image": "../images/newsletter-error.png",
       "subtitle": "subscribe error",
-      "text": "What this means is that we were unable to subsribe you to our service. We do appologise for the inconveniance and we would like you to try again. ",
-      "buttonText": ""
+      "text": "What this means is that we were unable to subscribe you to our service. We do apologise for the inconvenience and we would like you to try again. ",
+      "buttonText": "",
+      "buttonLinkTo": ""
     } 
   },
   "unsubscribe": {
@@ -35,8 +38,9 @@
       "titleColor": "negative",
       "image": "../images/newsletter-successful-unsubscribe.png",
       "subtitle": "successful Unsubscribe",
-      "text": "We’ve successfully unsubscribed you from our newsletter. You will not recieve any emails with new job offers from us. If this was a mistake, you can subsrcibe again.",
-      "buttonText": "BROWSE JOBS"
+      "text": "We’ve successfully unsubscribed you from our newsletter. You will not receive any emails with new job offers from us. If this was a mistake, you can subsrcibe again.",
+      "buttonText": "BROWSE JOBS",
+      "buttonLinkTo": "/"
     },
     "DEFAULT": {
       "ref": "ERROR",
@@ -44,8 +48,9 @@
       "titleColor": "gray_2",
       "image": "../images/newsletter-error.png",
       "subtitle": "Unsubscribe error",
-      "text": "This is not us keeping you from unsubscribing, but something went wrong with our service. We are so sorry for the inconveniance, can you try again?",
-      "buttonText": ""
+      "text": "This is not us keeping you from unsubscribing, but something went wrong with our service. We are so sorry for the inconvenience, can you try again?",
+      "buttonText": "",
+      "buttonLinkTo": ""
     } 
   }
 }

--- a/packages/jobboard/website/src/components/Newsletter/Layout.jsx
+++ b/packages/jobboard/website/src/components/Newsletter/Layout.jsx
@@ -20,11 +20,25 @@ const NewsletterLayout = ({
   isSubscribeSuccess,
   title,
   buttonText,
+  buttonLinkTo,
   image,
   subtitle,
   text,
   titleColor = 'gray_2',
 }) => {
+  const button = React.useMemo(() => {
+    if (buttonText) {
+      if (buttonLinkTo) {
+        return (
+          <Link className={styles.link} to={buttonLinkTo}>
+            <Button className={styles.button}>{buttonText}</Button>
+          </Link>
+        );
+      }
+      return <Button className={styles.button}>{buttonText}</Button>;
+    }
+  }, [buttonText, buttonLinkTo]);
+
   return (
     <Section className={styles.section}>
       <Flexbox className={styles.flex}>
@@ -64,9 +78,7 @@ const NewsletterLayout = ({
             >
               {text}
             </Typography>
-            {buttonText && (
-              <Button className={styles.button}>{buttonText}</Button>
-            )}
+            {button}
           </Flexbox>
         </div>
       </Flexbox>

--- a/packages/jobboard/website/src/components/Newsletter/layout.module.scss
+++ b/packages/jobboard/website/src/components/Newsletter/layout.module.scss
@@ -124,6 +124,10 @@ $navigation__height--desktop: 100px;
   max-width: 266px;
 }
 
+.link {
+  display: contents;
+}
+
 @include mediaQuery(">=mobile", "<1000px"){
   .text,.button,.subtitle, .title {
     text-align: center;

--- a/packages/jobboard/website/src/pages/newsletter/subscribe/already-confirmed.js
+++ b/packages/jobboard/website/src/pages/newsletter/subscribe/already-confirmed.js
@@ -15,6 +15,7 @@ const Subscribe = ({ data }) => {
       isSubscribeSuccess={result.ref === 'SUCCESS'}
       image={result.image}
       buttonText={result.buttonText}
+      buttonLinkTo={result.buttonLinkTo}
       title={result.title}
       subtitle={result.subtitle}
       text={result.text}
@@ -42,6 +43,7 @@ export const query = graphql`
           subtitle
           text
           buttonText
+          buttonLinkTo
           image {
             childImageSharp {
               fluid(maxWidth: 600) {

--- a/packages/jobboard/website/src/pages/newsletter/subscribe/error.js
+++ b/packages/jobboard/website/src/pages/newsletter/subscribe/error.js
@@ -15,6 +15,7 @@ const Subscribe = ({ data }) => {
       isSubscribeSuccess={result.ref === 'SUCCESS'}
       image={result.image}
       buttonText={result.buttonText}
+      buttonLinkTo={result.buttonLinkTo}
       title={result.title}
       subtitle={result.subtitle}
       text={result.text}
@@ -42,6 +43,7 @@ export const query = graphql`
           subtitle
           text
           buttonText
+          buttonLinkTo
           image {
             childImageSharp {
               fluid(maxWidth: 600) {

--- a/packages/jobboard/website/src/pages/newsletter/subscribe/success.js
+++ b/packages/jobboard/website/src/pages/newsletter/subscribe/success.js
@@ -15,6 +15,7 @@ const Subscribe = ({ data }) => {
       isSubscribeSuccess={result.ref === 'SUCCESS'}
       image={result.image}
       buttonText={result.buttonText}
+      buttonLinkTo={result.buttonLinkTo}
       title={result.title}
       subtitle={result.subtitle}
       text={result.text}
@@ -42,6 +43,7 @@ export const query = graphql`
           subtitle
           text
           buttonText
+          buttonLinkTo
           image {
             childImageSharp {
               fluid(maxWidth: 600) {

--- a/packages/jobboard/website/src/pages/newsletter/unsubscribe/error.js
+++ b/packages/jobboard/website/src/pages/newsletter/unsubscribe/error.js
@@ -14,6 +14,7 @@ const Unsubscribe = ({ data }) => {
     <NewsletterLayout
       image={result.image}
       buttonText={result.buttonText}
+      buttonLinkTo={result.buttonLinkTo}
       title={result.title}
       subtitle={result.subtitle}
       text={result.text}
@@ -42,6 +43,7 @@ export const query = graphql`
           subtitle
           text
           buttonText
+          buttonLinkTo
           image {
             childImageSharp {
               fluid(maxWidth: 600) {

--- a/packages/jobboard/website/src/pages/newsletter/unsubscribe/success.js
+++ b/packages/jobboard/website/src/pages/newsletter/unsubscribe/success.js
@@ -16,6 +16,7 @@ const Unsubscribe = ({ data, location }) => {
     <NewsletterLayout
       image={result.image}
       buttonText={result.buttonText}
+      buttonLinkTo={result.buttonLinkTo}
       title={result.title}
       subtitle={result.subtitle}
       text={result.text}
@@ -44,6 +45,7 @@ export const query = graphql`
           subtitle
           text
           buttonText
+          buttonLinkTo
           image {
             childImageSharp {
               fluid(maxWidth: 600) {


### PR DESCRIPTION
Newsletter links: newsletter/subscribe/already-confirmed/ and newsletter/subscribe/success/ and newsletter/unsubscribe/success/ are now leading to home.
Fix typos.