### PR TITLE
fixed focused option

### DIFF
--- a/packages/components/src/components/Listbox/Option.jsx
+++ b/packages/components/src/components/Listbox/Option.jsx
@@ -50,7 +50,7 @@ const Option = ({
         [styles.listbox__option__active]: active,
         [styles.listbox__option__selectedActive]: active && selected,
       })}
-      id={id}
+      id={id || `lb-option-${index}`}
       ref={optionRef}
       data-testid={testId}
       role="option"
@@ -96,7 +96,7 @@ Option.propTypes = {
   /**
    *
    */
-  id: PropTypes.string,
+  id: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
   /**
    *
    */

--- a/packages/components/src/components/Listbox/Option.jsx
+++ b/packages/components/src/components/Listbox/Option.jsx
@@ -1,4 +1,4 @@
-import React, { useCallback } from "react";
+import React, { useCallback, useEffect, useRef } from "react";
 import PropTypes from "prop-types";
 import classnames from "classnames";
 import styles from "./index.module.scss";
@@ -19,6 +19,14 @@ const Option = ({
   showCheckIcon = true,
   testId,
 }) => {
+  const optionRef = useRef();
+
+  useEffect(() => {
+    if (active && optionRef.current) {
+      optionRef.current.focus();
+    }
+  }, [active]);
+
   const handleClick = useCallback(
     (e) => {
       e.stopPropagation();
@@ -55,6 +63,7 @@ const Option = ({
       })}
       id={id}
       data-testid={testId}
+      ref={optionRef}
       role="option"
       aria-selected={selected}
       onClick={handleClick}

--- a/packages/components/src/components/Listbox/Option.jsx
+++ b/packages/components/src/components/Listbox/Option.jsx
@@ -9,10 +9,9 @@ const Option = ({
   children,
   className,
   disabled = false,
-  enableMultiselect = false,
   handleOptionClick,
   handleOptionFocus,
-  handleOptionMouseEnter,
+  handleOptionMouseMove,
   id,
   index,
   selected = false,
@@ -23,7 +22,7 @@ const Option = ({
 
   useEffect(() => {
     if (active && optionRef.current) {
-      optionRef.current.focus();
+      optionRef.current.scrollIntoView({ block: "nearest" });
     }
   }, [active]);
 
@@ -35,21 +34,17 @@ const Option = ({
     [handleOptionClick, disabled, index]
   );
 
-  const handleMouseEnter = useCallback(
+  const handleMouseMove = useCallback(
     (e) => {
       e.stopPropagation();
-      if (handleOptionMouseEnter && !disabled) handleOptionMouseEnter(index);
+      if (handleOptionMouseMove && !disabled) handleOptionMouseMove(index);
     },
-    [handleOptionMouseEnter, disabled, index]
+    [handleOptionMouseMove, disabled, index]
   );
 
-  const handleFocus = useCallback(
-    (e) => {
-      e.stopPropagation();
-      if (handleOptionFocus && !disabled) handleOptionFocus(index);
-    },
-    [handleOptionFocus, disabled, index]
-  );
+  const handleFocus = useCallback(() => {
+    if (handleOptionFocus && !disabled) handleOptionFocus(index);
+  }, [handleOptionFocus, disabled, index]);
 
   return (
     <div
@@ -58,19 +53,18 @@ const Option = ({
         [styles.disabled]: disabled,
         [styles.listbox__option__selected]: selected,
         [styles.listbox__option__active]: active,
-        [styles.listbox__option__selectedActive]:
-          enableMultiselect && active && selected,
+        [styles.listbox__option__selectedActive]: active && selected,
       })}
       id={id}
-      data-testid={testId}
       ref={optionRef}
+      data-testid={testId}
       role="option"
       aria-selected={selected}
       onClick={handleClick}
       onKeyPress={() => {}}
-      onMouseEnter={handleMouseEnter}
+      onMouseMove={handleMouseMove}
       onFocus={handleFocus}
-      tabIndex={0}
+      tabIndex={-1}
     >
       {showCheckIcon && selected && (
         <Icon className={`${styles.listbox__icon}`} icon="check" />
@@ -98,10 +92,6 @@ Option.propTypes = {
    */
   disabled: PropTypes.bool,
   /**
-   * If enabled it will show different color when multiple items are selected and hovered or focused
-   */
-  enableMultiselect: PropTypes.bool,
-  /**
    *
    */
   handleOptionClick: PropTypes.func,
@@ -112,7 +102,7 @@ Option.propTypes = {
   /**
    *
    */
-  handleOptionMouseEnter: PropTypes.func,
+  handleOptionMouseMove: PropTypes.func,
   /**
    *
    */

--- a/packages/components/src/components/Listbox/Option.jsx
+++ b/packages/components/src/components/Listbox/Option.jsx
@@ -10,7 +10,6 @@ const Option = ({
   className,
   disabled = false,
   handleOptionClick,
-  handleOptionFocus,
   handleOptionMouseMove,
   id,
   index,
@@ -42,10 +41,6 @@ const Option = ({
     [handleOptionMouseMove, disabled, index]
   );
 
-  const handleFocus = useCallback(() => {
-    if (handleOptionFocus && !disabled) handleOptionFocus(index);
-  }, [handleOptionFocus, disabled, index]);
-
   return (
     <div
       aria-disabled={disabled}
@@ -63,7 +58,6 @@ const Option = ({
       onClick={handleClick}
       onKeyPress={() => {}}
       onMouseMove={handleMouseMove}
-      onFocus={handleFocus}
       tabIndex={-1}
     >
       {showCheckIcon && selected && (
@@ -95,10 +89,6 @@ Option.propTypes = {
    *
    */
   handleOptionClick: PropTypes.func,
-  /**
-   *
-   */
-  handleOptionFocus: PropTypes.func,
   /**
    *
    */

--- a/packages/components/src/components/Listbox/__tests__/index.test.jsx
+++ b/packages/components/src/components/Listbox/__tests__/index.test.jsx
@@ -10,6 +10,8 @@ import Listbox from "../index";
 
 describe("Listbox Component", () => {
   describe("Single Select Listbox", () => {
+    window.HTMLElement.prototype.scrollIntoView = jest.fn();
+
     test("Empty renders without issue", () => {
       const { container } = render(<Listbox testId="listbox-1" />);
       const listbox = getByTestId(container, "listbox-1");

--- a/packages/components/src/components/Listbox/__tests__/index.test.jsx
+++ b/packages/components/src/components/Listbox/__tests__/index.test.jsx
@@ -108,15 +108,15 @@ describe("Listbox Component", () => {
       listbox.focus();
 
       fireEvent.keyDown(listbox, { key: "a" });
-      expect(listbox.getAttribute("aria-activedescendant")).toBe("0"); // next with letter a
+      expect(listbox.getAttribute("aria-activedescendant")).toBe("lb-option-0"); // next with letter a
       fireEvent.keyDown(listbox, { key: "a" });
-      expect(listbox.getAttribute("aria-activedescendant")).toBe("3"); // next with letter a
+      expect(listbox.getAttribute("aria-activedescendant")).toBe("lb-option-3"); // next with letter a
       fireEvent.keyDown(listbox, { key: "a" });
-      expect(listbox.getAttribute("aria-activedescendant")).toBe("4"); // next with letter a
+      expect(listbox.getAttribute("aria-activedescendant")).toBe("lb-option-4"); // next with letter a
       fireEvent.keyDown(listbox, { key: "a" });
-      expect(listbox.getAttribute("aria-activedescendant")).toBe("0"); // next with letter a
+      expect(listbox.getAttribute("aria-activedescendant")).toBe("lb-option-0"); // next with letter a
       fireEvent.keyDown(listbox, { key: "d" });
-      expect(listbox.getAttribute("aria-activedescendant")).toBe("0"); // next with 'ad' (preserve position)
+      expect(listbox.getAttribute("aria-activedescendant")).toBe("lb-option-0"); // next with 'ad' (preserve position)
     });
   });
 });

--- a/packages/components/src/components/Listbox/index.jsx
+++ b/packages/components/src/components/Listbox/index.jsx
@@ -195,7 +195,7 @@ const Listbox = ({
 
   const handleKeyDown = useCallback(
     (event) => {
-      if (event.keyCode !== Keys.Tab) {
+      if (event.keyCode === Keys.ArrowDown || event.keyCode === Keys.ArrowUp) {
         event.preventDefault();
         event.stopPropagation();
       }
@@ -206,9 +206,6 @@ const Listbox = ({
           break;
         case Keys.ArrowDown:
           focusNext();
-          break;
-        case Keys.Space:
-          handleOptionClick(focusedIndex);
           break;
         case Keys.Enter:
           handleOptionClick(focusedIndex);
@@ -300,7 +297,7 @@ const Listbox = ({
       })}
       id={id}
       onFocus={handleOnFocus}
-      onKeyDown={handleKeyDown}
+      onKeyDownCapture={handleKeyDown}
       onMouseEnter={handleMouseEnter}
       ref={listboxRef}
       role="listbox"

--- a/packages/components/src/components/Listbox/index.jsx
+++ b/packages/components/src/components/Listbox/index.jsx
@@ -263,10 +263,6 @@ const Listbox = ({
     setFocusedIndex(-1);
   }, []);
 
-  const handleOptionFocus = useCallback((index) => {
-    setFocusedIndex(index);
-  }, []);
-
   const renderChildren = useCallback(() => {
     let index = -1;
 
@@ -280,7 +276,6 @@ const Listbox = ({
       return React.cloneElement(child, {
         handleOptionClick,
         handleOptionMouseMove,
-        handleOptionFocus,
         index,
         active,
         selected,
@@ -295,7 +290,6 @@ const Listbox = ({
     selectedOptions,
     handleOptionClick,
     handleOptionMouseMove,
-    handleOptionFocus,
     showCheckIcon,
     enableMultiselect,
   ]);

--- a/packages/components/src/components/Listbox/index.jsx
+++ b/packages/components/src/components/Listbox/index.jsx
@@ -387,9 +387,15 @@ Listbox.propTypes = {
   disabled: PropTypes.bool,
   /**
    * Array of IDs of defaultly selected options. You need to define ID of every option to enable default selection.
+   * Provide string of ID or array with single ID if multi selection is off.
+   * Provide array with IDs if multi selection is on.
+   * Providing array will multiple IDs on single selection Listbox will set only first Option as defaultly selected.
    */
-  defaultSelected: PropTypes.arrayOf(
-    PropTypes.oneOfType([PropTypes.number, PropTypes.string])
+  defaultSelected: PropTypes.oneOfType(
+    PropTypes.arrayOf(
+      PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
+      PropTypes.string
+    )
   ),
   /**
    * If set to true enables selection of multiple options

--- a/packages/components/src/components/Listbox/index.jsx
+++ b/packages/components/src/components/Listbox/index.jsx
@@ -391,12 +391,12 @@ Listbox.propTypes = {
    * Provide array with IDs if multi selection is on.
    * Providing array will multiple IDs on single selection Listbox will set only first Option as defaultly selected.
    */
-  defaultSelected: PropTypes.oneOfType(
+  defaultSelected: PropTypes.oneOfType([
     PropTypes.arrayOf(
-      PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
-      PropTypes.string
-    )
-  ),
+      PropTypes.oneOfType([PropTypes.number, PropTypes.string])
+    ),
+    PropTypes.string,
+  ]),
   /**
    * If set to true enables selection of multiple options
    */

--- a/packages/components/src/components/Listbox/index.module.scss
+++ b/packages/components/src/components/Listbox/index.module.scss
@@ -30,7 +30,7 @@
     user-select: none; /* Standard */
 
     &__active {
-      background-color: $gray_5;
+      background-color: #f1f1f1;
     }
 
     &__selected {

--- a/packages/components/src/components/Listbox/index.stories.jsx
+++ b/packages/components/src/components/Listbox/index.stories.jsx
@@ -1,4 +1,4 @@
-import React, { useRef } from "react";
+import React, { useRef, useState } from "react";
 import Listbox from "./index";
 
 export default {
@@ -121,7 +121,7 @@ Story4.parameters = {
 export const Story5 = () => {
   return (
     <Listbox>
-      <Listbox.Option>Ananas</Listbox.Option>
+      <Listbox.Option defaultSelected>Ananas</Listbox.Option>
       <Listbox.Option disabled>Avocado</Listbox.Option>
       <Listbox.Option>Banana</Listbox.Option>
       <Listbox.Option>Bush</Listbox.Option>
@@ -141,13 +141,16 @@ Story5.parameters = {
 
 export const Story6 = () => {
   const listboxRef = useRef();
+
+  const [selectedItems, setSelectedItems] = useState([]);
+
   return (
     <div>
       <div>
         <Listbox enableMultiselect forwardRef={listboxRef}>
           <Listbox.Option>Ananas</Listbox.Option>
           <Listbox.Option disabled>Avocado</Listbox.Option>
-          <Listbox.Option>Banana</Listbox.Option>
+          <Listbox.Option id="banana-id">Banana</Listbox.Option>
           <Listbox.Option>Bush</Listbox.Option>
           <Listbox.Option disabled>Bloom</Listbox.Option>
           <Listbox.Option>Doom</Listbox.Option>
@@ -160,6 +163,14 @@ export const Story6 = () => {
       >
         Clear
       </button>
+      <button
+        onClick={() => {
+          setSelectedItems(listboxRef.current.getSelectedOptions());
+        }}
+      >
+        Print Selection
+      </button>
+      <div>{JSON.stringify(selectedItems, null, 2)}</div>
     </div>
   );
 };
@@ -169,6 +180,60 @@ Story6.parameters = {
     description: {
       story: `This listbox can expose inner functions. In this example, listbox can expose 'clear' function.
       Calling this function will clear all selection`,
+    },
+  },
+};
+
+export const Story7 = () => {
+  return (
+    <div>
+      <p>
+        <strong>Multiselect</strong>
+      </p>
+      <Listbox defaultSelected={["ananas-id", "banana-id"]} enableMultiselect>
+        <Listbox.Option id="ananas-id">Ananas</Listbox.Option>
+        <Listbox.Option id="avocado-id" disabled>
+          Avocado
+        </Listbox.Option>
+        <Listbox.Option id="banana-id">Banana</Listbox.Option>
+        <Listbox.Option>Bush</Listbox.Option>
+        <Listbox.Option disabled>Bloom</Listbox.Option>
+        <Listbox.Option>Doom</Listbox.Option>
+      </Listbox>
+      <p>
+        <strong>Singleselect ID as Array</strong>
+      </p>
+      <Listbox defaultSelected={["banana-id"]}>
+        <Listbox.Option id="ananas-id">Ananas</Listbox.Option>
+        <Listbox.Option id="avocado-id" disabled>
+          Avocado
+        </Listbox.Option>
+        <Listbox.Option id="banana-id">Banana</Listbox.Option>
+        <Listbox.Option>Bush</Listbox.Option>
+        <Listbox.Option disabled>Bloom</Listbox.Option>
+        <Listbox.Option>Doom</Listbox.Option>
+      </Listbox>
+      <p>
+        <strong>Singleselect ID as string</strong>
+      </p>
+      <Listbox defaultSelected="banana-id">
+        <Listbox.Option id="ananas-id">Ananas</Listbox.Option>
+        <Listbox.Option id="avocado-id" disabled>
+          Avocado
+        </Listbox.Option>
+        <Listbox.Option id="banana-id">Banana</Listbox.Option>
+        <Listbox.Option>Bush</Listbox.Option>
+        <Listbox.Option disabled>Bloom</Listbox.Option>
+        <Listbox.Option>Doom</Listbox.Option>
+      </Listbox>
+    </div>
+  );
+};
+Story7.storyName = "Default selection";
+Story7.parameters = {
+  docs: {
+    description: {
+      story: `This shows defaultly selected options`,
     },
   },
 };

--- a/packages/components/src/components/Listbox/index.stories.jsx
+++ b/packages/components/src/components/Listbox/index.stories.jsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useRef } from "react";
 import Listbox from "./index";
 
 export default {
@@ -135,6 +135,40 @@ Story5.parameters = {
   docs: {
     description: {
       story: `Some options can be disabled.`,
+    },
+  },
+};
+
+export const Story6 = () => {
+  const listboxRef = useRef();
+  return (
+    <div>
+      <div>
+        <Listbox enableMultiselect forwardRef={listboxRef}>
+          <Listbox.Option>Ananas</Listbox.Option>
+          <Listbox.Option disabled>Avocado</Listbox.Option>
+          <Listbox.Option>Banana</Listbox.Option>
+          <Listbox.Option>Bush</Listbox.Option>
+          <Listbox.Option disabled>Bloom</Listbox.Option>
+          <Listbox.Option>Doom</Listbox.Option>
+        </Listbox>
+      </div>
+      <button
+        onClick={() => {
+          listboxRef.current.clear();
+        }}
+      >
+        Clear
+      </button>
+    </div>
+  );
+};
+Story6.storyName = "Controlled";
+Story6.parameters = {
+  docs: {
+    description: {
+      story: `This listbox can expose inner functions. In this example, listbox can expose 'clear' function.
+      Calling this function will clear all selection`,
     },
   },
 };


### PR DESCRIPTION
Solved bugs with focused options.
1. Previously, options that were "active" could be "blurred" (not focused). This means that actual focused option could be out of sync with option that was showing as focused. Now, focused option is same as active one. This means that arrow up/down keys will change actual focus, not just set style. If listbox is showing vertical scrollbar, focused option will always be visible. (Shift + Tab is working now).

2. Removed "space" key binding. Space key should not select focused option (only Enter).

3. Note: I don't think that "tab" key should act same as "arrow down". Otherwise, once listbox option is focused, user cannot move focus to any other element and therefore is stuck in listbox options. 


-- EDIT

1. Focus won't target options anymore. Pressing Tab will jump to next component (not Option inside Listbox).
2. If Listbox is small and cannot show all Options (has vertical scroll), moving arrows up and down will follow active Option, making it always visible.
3. Fixed aria bug when none of the Options is selected.
4. Add special property named "forwardRef". This is acutally ref which will be passed to Listbox. Listbox will attach 'clear' function on to this ref. Ref will now expose 'clear' function, making it available to other components outside Listbox.