### PR TITLE
Bugfix/select issues

### DIFF
--- a/packages/components/src/components/Select/index.jsx
+++ b/packages/components/src/components/Select/index.jsx
@@ -141,6 +141,7 @@ const Select = ({
 
   const clearSelection = useCallback(() => {
     listboxRef.current.clear();
+    setSelection([]);
   }, []);
 
   const onListboxChange = useCallback(

--- a/packages/components/src/components/Select/index.module.scss
+++ b/packages/components/src/components/Select/index.module.scss
@@ -117,6 +117,7 @@
 
 .portal {
   padding-top: 15px;
+  z-index: 100;
 }
 
 .card {

--- a/packages/components/src/components/Select/index.stories.jsx
+++ b/packages/components/src/components/Select/index.stories.jsx
@@ -76,3 +76,21 @@ Story4.args = {
   title: "Fruit",
   label: "Fruit",
 };
+
+export const Story5 = () => {
+  return (
+    <div>
+      <Select clear pill multiselect confirmChoice label="Fruit">
+        <Select.Option>Ananas</Select.Option>
+        <Select.Option>Banana</Select.Option>
+        <Select.Option>Avocado</Select.Option>
+      </Select>
+      <Select clear pill multiselect label="Fruit">
+        <Select.Option>Ananas</Select.Option>
+        <Select.Option>Banana</Select.Option>
+        <Select.Option>Avocado</Select.Option>
+      </Select>
+    </div>
+  );
+};
+Story5.storyName = "Multiselect Pills";


### PR DESCRIPTION
Set z-index to 100. This will prevent other components to appear in front of Select dropdown. 
Fixed "Clear All" button behavior if there is no "Confirm" button. Now it correctly stores state to an empty array.