### PR TITLE
transform navigation on scroll instead of changing height

### DIFF
--- a/packages/components/src/components/Navigation/Navigation.stories.js
+++ b/packages/components/src/components/Navigation/Navigation.stories.js
@@ -1,5 +1,6 @@
 import React from "react";
 import Button from "../Button";
+import Tag from "../Tag";
 import Typography from "../Typography";
 import Navigation from "./index";
 
@@ -38,7 +39,7 @@ Story1.argTypes = {
 };
 
 export const Story2 = (args) => (
-  <div style={{ height: "150vh" }}>
+  <div style={{}}>
     <Navigation
       {...args}
       Logo={<img width="100%" src="/images/navigation.png" />}
@@ -47,6 +48,12 @@ export const Story2 = (args) => (
       <Typography className="link">Two link</Typography>
       <Button variant="secondary">Post a job</Button>
     </Navigation>
+
+    <div style={{ display: "flex", flexDirection: "column" }}>
+      {Array.from(Array(50).keys()).map((e, i) => (
+        <Tag>This is a sample #hashtag {i}</Tag>
+      ))}
+    </div>
   </div>
 );
 Story2.storyName = "Multiple links example";

--- a/packages/components/src/components/Navigation/index.module.scss
+++ b/packages/components/src/components/Navigation/index.module.scss
@@ -16,7 +16,10 @@ $navigation__animation__length: 0.6s;
   position: -webkit-sticky;
   position: sticky;
   top: 0;
-  transition: padding #{$navigation__animation__length} cubic-bezier(0.5, 1, 0.89, 1), height #{$navigation__animation__length} cubic-bezier(0.5, 1, 0.89, 1), box-shadow #{$navigation__animation__length} cubic-bezier(0.5, 1, 0.89, 1);
+  transition: 
+    padding #{$navigation__animation__length} cubic-bezier(0.5, 1, 0.89, 1),
+    transform #{$navigation__animation__length} cubic-bezier(0.5, 1, 0.89, 1),
+    box-shadow #{$navigation__animation__length} cubic-bezier(0.5, 1, 0.89, 1);
   z-index: 100;
 
   &.transparent {
@@ -88,11 +91,10 @@ $navigation__animation__length: 0.6s;
 
 .scroll {
   box-shadow: 0px 5px 20px rgba(69, 85, 22, 0.1);
-  height: $navigation__mobile__height;
+  transform: translateY(-30px);
+  padding-top: 40px;
   padding-bottom: 10px;
-  padding-top: 10px;
   top: 0;
-
 }
 
 @include mediaQuery(">=mobile","<tabletPortrait"){


### PR DESCRIPTION
Before, when page that has Navigation was scrolled, elements below it could appear as "shaking" for small amount of time. If content below navigation was large enough and user/client tried to scroll to the bottom of the page by dragging page scroll bar from top to bottom, scroll bar would get stuck somewhere in between page. 

Bug described above was caused by height transition of the Navigation component (shrinking from 100px to 70px). This PR is fix for "shaking" and "scroll stuck" bugs. Navigation won't change size anymore, but it will change top-bottom padding ratio and move itself 30px beyond top of the screen, making animation looking same as if it had height animation.

Updated storybook example - Tags below Navigation won't shake anymore. Scroll can be dragged to bottom in one drag.