### PR TITLE
add prop to input to make label dissapear on not empty state

### DIFF
--- a/packages/components/src/components/FieldLayout/index.jsx
+++ b/packages/components/src/components/FieldLayout/index.jsx
@@ -22,6 +22,7 @@ const Field = ({
   removeChildrenStyle,
   removeBottomBorder,
   hideLabel,
+  hideLabelOnFocus,
 }) => {
   return (
     <div
@@ -37,7 +38,9 @@ const Field = ({
         id={labelId}
         aria-hidden={hideLabel}
         htmlFor={labelHtmlFor}
-        className={styles.label}
+        className={classnames(styles.label, {
+          [styles.labelHidden]: hideLabelOnFocus,
+        })}
       >
         {label} {required && "*"}
       </label>
@@ -86,6 +89,11 @@ const FieldPropTypes = {
    * children.
    */
   errorMessage: PropTypes.string,
+  /**
+   * If set to true it will hide label when input is not empty of is focused
+   * instead of setting it to top.
+   */
+  hideLabelOnFocus: PropTypes.bool,
   /**
    * Id applied to the wrapper element
    */

--- a/packages/components/src/components/FieldLayout/index.module.scss
+++ b/packages/components/src/components/FieldLayout/index.module.scss
@@ -114,7 +114,8 @@ $padding_bottom: 7px;
     height 200ms cubic-bezier(0, 0, 0.2, 1) 0ms,
     font-size 200ms cubic-bezier(0, 0, 0.2, 1) 0ms,
     bottom 200ms cubic-bezier(0, 0, 0.2, 1) 0ms,
-    transform 200ms cubic-bezier(0, 0, 0.2, 1) 0ms;
+    transform 200ms cubic-bezier(0, 0, 0.2, 1) 0ms,
+    opacity 200ms cubic-bezier(0, 0, 0.2, 1) 0ms;
   z-index: 0;
 }
 
@@ -128,14 +129,17 @@ $padding_bottom: 7px;
 }
 
 .wrapper:focus-within, .wrapper:focus {
-  .label {
+  .label:not(.labelHidden) {
     color: $green_2;
   }
 }
 
 .wrapper:focus,
 .wrapper:focus-within, .wrapper:not(.empty) {
-  .label {
+  .labelHidden {
+    opacity: 0;
+  }
+  .label:not(.labelHidden) {
     font-size: 0.85em;
     height: 1.17647em;
     transform: translate(0px, 0px);

--- a/packages/components/src/components/Input/Input.stories.jsx
+++ b/packages/components/src/components/Input/Input.stories.jsx
@@ -1,3 +1,4 @@
+import React from "react";
 import Input from "./index";
 import FieldLayout from "../FieldLayout";
 
@@ -45,3 +46,18 @@ Story5.args = {
   label: "Max 10 chars",
   maxLength: 10,
 };
+
+export const Story6 = () => {
+  return (
+    <div>
+      <Input hideLabelOnFocus label="Banana" />
+      <br />
+      <Input hideLabelOnFocus label="Banana Banana" />
+      <br />
+      <Input hideLabelOnFocus label="Banana Banana Banana" />
+      <br />
+    </div>
+  );
+};
+
+Story6.storyName = "Hide label on focus";

--- a/packages/components/src/components/Input/index.jsx
+++ b/packages/components/src/components/Input/index.jsx
@@ -12,6 +12,7 @@ const Input = ({
   error,
   errorMessage,
   id,
+  hideLabelOnFocus,
   label,
   maxLength,
   onChange,
@@ -42,6 +43,7 @@ const Input = ({
       label={label}
       required={required}
       className={className}
+      hideLabelOnFocus={hideLabelOnFocus}
     >
       <input
         id={id}
@@ -79,6 +81,11 @@ Input.propTypes = {
   required: PropTypes.bool,
   maxLength: PropTypes.number,
   defaultValue: PropTypes.string,
+  /**
+   * If set to true it will hide label when input is not empty of is focused
+   * instead of setting it to top.
+   */
+  hideLabelOnFocus: PropTypes.bool,
 };
 
 Input.defaultProps = {


### PR DESCRIPTION
FieldLayout and Input component now have property to make label (placeholder) to disappear when component is focused or not empty. Added story example. 