### PR TITLE
fix stuck scroll state

### DIFF
--- a/packages/components/src/components/Navigation/index.jsx
+++ b/packages/components/src/components/Navigation/index.jsx
@@ -35,8 +35,11 @@ const Navigation = ({
       }
     };
     window.addEventListener("scroll", scrollHandler);
-    return () => window.removeEventListener("scroll", scrollHandler);
-  }, [scrolled]);
+    return () => {
+      enableScroll();
+      window.removeEventListener("scroll", scrollHandler);
+    };
+  }, [enableScroll, scrolled]);
 
   const toggleMenu = useCallback(() => {
     setIsOpened(!opened);


### PR DESCRIPTION
Enable scroll when component is unmounting. This will fix stuck scroll state when switching pages through mobile menu.