### PR TITLE
add trailing slash to search page

### DIFF
--- a/packages/jobboard/website/src/components/Hero/index.jsx
+++ b/packages/jobboard/website/src/components/Hero/index.jsx
@@ -49,7 +49,7 @@ const Hero = ({
           <Button onClick={scrollToSubscribe} className={'link--primary'}>
             {callToActionSubscribe}
           </Button>
-          <Link to="/search" className={'link--secondary'}>
+          <Link to="/search/" className={'link--secondary'}>
             {callToActionSearch}
           </Link>
         </div>

--- a/packages/jobboard/website/src/components/Layout/index.jsx
+++ b/packages/jobboard/website/src/components/Layout/index.jsx
@@ -29,7 +29,7 @@ const Layout = ({ children, head = {}, stickyFooter, scrollToTop }) => {
           </Link>
         }
       >
-        <Link className={`${styles.centerAlignedLink} link`} to="/search">
+        <Link className={`${styles.centerAlignedLink} link`} to="/search/">
           Search
         </Link>
         <a


### PR DESCRIPTION
Default trailing slash in Search page will prevent query params to be removed. Requests to Search page should now default to:
https://jobs.crocoder.dev/search/?page=1 (with trailing slash) instead of
https://jobs.crocoder.dev/search?page=1 (without trailing slash).

Request made on Search page without trailing slash on production server will lead to:
https://jobs.crocoder.dev/search/ (page without query params).