### PR TITLE
set view post text to single line

### DIFF
--- a/packages/jobboard/website/src/components/Job/Post/index.jsx
+++ b/packages/jobboard/website/src/components/Job/Post/index.jsx
@@ -57,7 +57,7 @@ const JobPost = ({
           fontSize={18}
           color="green_4"
         >
-          <a href={jobUrl} className={styles.link}>
+          <a href={jobUrl} className={styles.link} style={{ whiteSpace: 'nowrap' }}>
             VIEW POST <Icon icon="arrow-right" className={styles.icon} />
           </a>
         </Typography>


### PR DESCRIPTION
View Post text on Job post cards will now always be displayed as single line, it won't break due other elements.