### PR TITLE
set company title from title or heading

### DIFF
--- a/packages/jobboard/scrapper/src/services/gh.js
+++ b/packages/jobboard/scrapper/src/services/gh.js
@@ -40,7 +40,7 @@ const getUrls = async (browser, url) => {
   }
 
   return await page.evaluate((remoteWords) => {
-    const companyName = document.querySelector("h1");
+    const companyName = document.querySelector('[property="og:title"]') || document.querySelector("h1");
     const logoUrl = document.querySelector("#logo > img");
     const isRemote = [...document.querySelectorAll(".location")];
     const urls = [...document.querySelectorAll("section > div > a")]


### PR DESCRIPTION
When scrapping, take company name from metadata rather than from H1.
This will fix bad company name for Netlify. (only 'Netlify' instead of 'Current Job Openings at Netlify').