### PR TITLE
remove duplicate H1 titles from jobboard

### DIFF
--- a/packages/jobboard/website/src/components/Job/Section/index.jsx
+++ b/packages/jobboard/website/src/components/Job/Section/index.jsx
@@ -15,10 +15,10 @@ const Label = styled(Typography)`
   }
 `;
 
-const JobSection = ({ title, children, style }) => {
+const JobSection = ({ title, children, style, titleElement = 'h2' }) => {
   return (
     <Section backgroundColor="blue_6" removeMobilePadding>
-      <Label fontWeight={700} fontSize={50} color="gray_2" element="h1">
+      <Label fontWeight={700} fontSize={50} color="gray_2" element={titleElement}>
         {title}
       </Label>
       {children}

--- a/packages/jobboard/website/src/pages/archived-jobs.js
+++ b/packages/jobboard/website/src/pages/archived-jobs.js
@@ -12,7 +12,7 @@ const ArchivedJobs = () => {
         description: '',
       }}
     >
-      <JobSection title="All Archived Jobs">
+      <JobSection title="All Archived Jobs" titleElement="h1">
         <ArchivedJobList />
       </JobSection>
     </Layout>

--- a/packages/jobboard/website/src/pages/other-it-jobs.js
+++ b/packages/jobboard/website/src/pages/other-it-jobs.js
@@ -18,7 +18,7 @@ const AllOtherITJobsPage = ({ location }) => {
         description: '',
       }}
     >
-      <JobSection title="All other remote IT Jobs">
+      <JobSection title="All other remote IT Jobs" titleElement="h1">
         <OtherJobList scrollToJobWithIndex={scrollToJobWithIndex} />
       </JobSection>
       <Newsletter />

--- a/packages/jobboard/website/src/pages/software-developer-jobs.js
+++ b/packages/jobboard/website/src/pages/software-developer-jobs.js
@@ -18,7 +18,7 @@ const AllSoftwareDeveloperJobsPage = ({ location }) => {
         description: '',
       }}
     >
-      <JobSection title="All Remote Software Developer Jobs">
+      <JobSection title="All Remote Software Developer Jobs" titleElement="h1">
         <DevJobList scrollToJobWithIndex={scrollToJobWithIndex} />
       </JobSection>
       <Newsletter />


### PR DESCRIPTION
Removed duplicate H1 elements from Jobboards homepage. 
There is now only one H1 (Crocoder Jobs)