### PR TITLE
fixed mobile header height and position when is opened

### DIFF
--- a/packages/components/src/components/Navigation/index.jsx
+++ b/packages/components/src/components/Navigation/index.jsx
@@ -22,7 +22,7 @@ const Navigation = ({
 }) => {
   const [scrolled, setIsScrolled] = useState(defaultScrolled || false);
   const [opened, setIsOpened] = useState(false);
-  const { isMobile } = useDevice({ mobile: 1, tablet: 720 });
+  const { isMobile } = useDevice({ mobile: 1, tablet: 721 });
   const { disableScroll, enableScroll } = useScrollPrevent();
 
   useEffect(() => {
@@ -49,7 +49,6 @@ const Navigation = ({
       enableScroll();
     }
   }, [opened, isMobile, disableScroll, enableScroll]);
-
 
   return (
     <header

--- a/packages/components/src/components/Navigation/index.module.scss
+++ b/packages/components/src/components/Navigation/index.module.scss
@@ -37,6 +37,7 @@ $header__animation__length: 0.6s;
   @include mediaQuery(">=0px", "<=720px"){
     flex-wrap: wrap;
     padding: 10px 0 15px 25px;
+    height: $header__mobile__height;
 
     &.transparent {  
       height: $header__mobile__height;
@@ -99,17 +100,13 @@ $header__animation__length: 0.6s;
 
 .scroll {
   box-shadow: 0px 5px 20px rgba(69, 85, 22, 0.1);
-  transform: translateY(-30px);
-  padding-top: 40px;
-  padding-bottom: 10px;
   top: 0;
 
-  @include mediaQuery(">=0px", "<=720px"){
-    padding-top: 35px;
+  @include mediaQuery(">720px"){
+    transform: translateY(-30px);
+    padding-top: 40px;
     padding-bottom: 10px;
-    top: 0;
   }
-
 }
 
 @include mediaQuery(">=0px", "<=720px"){


### PR DESCRIPTION
Mobile header will preserve height (64px) even when user is scrolling. 

Fixed positioning bug when header was scrolled and hamburger menu was open.
Fixed bug on 720px wide screen where hamburger icon was not visible.