### PR TITLE
Fixed issue in "Cancel a running Promise" exercise

### DIFF
--- a/apps/company-website/src/pages/blog/promises-exercises.mdx
+++ b/apps/company-website/src/pages/blog/promises-exercises.mdx
@@ -372,11 +372,12 @@ function createCancellationToken() {
 
 function fetchData(cancellationToken) {
     return new Promise((resolve, reject) => {
-        setTimeout(() => {
+        const timerID = setTimeout(() => {
             resolve("Data fetched");
         }, 3000);
 
         cancellationToken.token.catch(() => {
+            clearTimeout(timerID)
             reject(new Error('Operation cancelled'));
         });
     });


### PR DESCRIPTION
This code allows really to cancel `setTimeout()` inside promise. Because without it `resolve()` will happen, even after cancellation.